### PR TITLE
Enable early map vote

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -119,7 +119,7 @@ ID_CONSOLE_JOBSLOT_DELAY 15
 ALLOW_VOTE_RESTART
 
 ## allow players to initiate a map-change vote
-#ALLOW_VOTE_MAP
+ALLOW_VOTE_MAP
 
 ## allow players to rock the vote, or to vote on the map again if they didn't like the last results
 #ALLOW_ROCK_THE_VOTE
@@ -128,7 +128,7 @@ ALLOW_VOTE_RESTART
 #MAX_ROCKING_VOTES 1
 
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
-VOTE_DELAY 6000
+VOTE_DELAY 2400
 
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 1800


### PR DESCRIPTION
Enables early map vote, and reduces the timer between votes.